### PR TITLE
Add gif support to buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ https://github.com/brandoncc/heroku-buildpack-vips
 VIPS_VERSION=x.y.z ./build.sh
 ```
 
+You may also target specific Heroku stack version(s) by passing them in as arguments.
+
+```sh
+VIPS_VERSION=x.y.z ./build.sh 20 18
+# Will only build heroku-20 and heroku-18 stacks, in that order
+```
+
 After building a tar file, it will be copied to the `build` directory. Then you should commit this changes to git.
 
 ## Build configuration (heroku-18)

--- a/README.md
+++ b/README.md
@@ -114,15 +114,15 @@ enable radiance support: yes
 enable analyze support: yes
 enable PPM support: yes
 use fftw3 for FFT: yes
-Magick package: none
-Magick API version: none
-load with libMagick: no
-save with libMagick: no
+Magick package: MagickCore
+Magick API version: magick6
+load with libMagick: yes
+save with libMagick: yes
 accelerate loops with orc: yes
 ICC profile support with lcms: yes (lcms2)
 file import with niftiio: no
 file import with libheif: yes
-file import with OpenEXR: no
+file import with OpenEXR: yes
 file import with OpenSlide: no
 file import with matio: no
 PDF import with PDFium: no

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,11 @@
 # set -x
 set -e
 
-STACK_VERSIONS=(16 18 20)
+if [ "$#" -eq 0 ]; then
+  STACK_VERSIONS=(16 18 20)
+else
+  STACK_VERSIONS=( "$@" )
+fi
 
 for stack_version in "${STACK_VERSIONS[@]}"; do
   image_name=libvips-heroku-$stack_version:$VIPS_VERSION

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -36,7 +36,8 @@ RUN apt-get update && apt-get install -y \
   libxml2-dev \
   libfftw3-dev \
   libpoppler-glib-dev \
-  libwebp-dev
+  libwebp-dev \
+  libmagickcore-dev
 
 # build our stack to this prefix
 ARG VIPS_PREFIX=/usr/local/vips


### PR DESCRIPTION
### Purpose

Allow vips to save gifs, needed for a handful of user avatars.

### Summary

- Add libmagickcore-dev to container
- Build a fresh copy of heroku-20 with `magicsave` enabled in `vips`
- Allow specific targeting of builds

### Guidance

Concerns? This is running and working on demo (see artifacts). I also did not bother updating the other builds (16, 18) as we aren't using them.

### Artifacts

https://github.com/brandoncc/heroku-buildpack-vips/issues/16

https://demo.betterup.co/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBZzRWIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--55727bb899acab700c6cba1f1e1399a8338fde5a/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdDVG9MWm05eWJXRjBTU0lJWjJsbUJqb0dSVlE2REdGMWRHOXliM1JVT2dwellYWmxjbnNHT2dwemRISnBjRlE2RTNKbGMybDZaVjkwYjE5bWFXeHNXd2RwQVpacEFaWT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--4485f0e0c06d392cc86399d1f7f3336d8f161a87/1_G0gDmLFBmr2Wagv4zn29wQ.gif
